### PR TITLE
Add embedded Google Map to ride detail pages

### DIFF
--- a/_includes/_sidebar_ride.html
+++ b/_includes/_sidebar_ride.html
@@ -14,6 +14,31 @@
 		</ul>
 	</div>
 
+	{% if page.ride.directions %}
+	{% comment %}Handle both /place/.../@LAT,LNG and /search/LAT,LNG URL formats{% endcomment %}
+	{% if page.ride.directions contains '/@' %}
+		{% assign coords_part = page.ride.directions | split: '/@' | last | split: '/' | first %}
+	{% elsif page.ride.directions contains '/search/' %}
+		{% assign coords_part = page.ride.directions | split: '/search/' | last | split: '?' | first %}
+	{% else %}
+		{% assign coords_part = '' %}
+	{% endif %}
+	{% assign coords_array = coords_part | replace: '+', '' | split: ',' %}
+	{% assign lat = coords_array[0] | strip %}
+	{% assign lng = coords_array[1] | strip %}
+	<div class="b30">
+		<iframe
+			width="300"
+			height="300"
+			style="border:0; border-radius:3px;"
+			loading="lazy"
+			allowfullscreen
+			referrerpolicy="no-referrer-when-downgrade"
+			src="https://www.google.com/maps/embed/v1/place?key=AIzaSyDQCDC7v-pRLTW4HIGl6wCEt8yGFaDEOXo&q={{ lat }},{{ lng }}&zoom=14">
+		</iframe>
+	</div>
+	{% endif %}
+
   <img class="b30" src="{{ site.urlimg }}/gvdbr_logo_271_168.png" alt="">
 
 


### PR DESCRIPTION
## Summary
- Adds an embedded Google Map to the ride detail sidebar, positioned below the Ride Details box
- Automatically extracts coordinates from the existing `directions` URL in ride frontmatter
- Supports both `/place/` and `/search/` Google Maps URL formats

## Test plan
- [x] Verify map displays correctly on ride pages with `/place/` URLs (e.g., Bangs Canyon Advanced)
- [x] Verify map displays correctly on ride pages with `/search/` URLs (e.g., North Desert Easy)
- [x] Confirm map is sized appropriately (300x300) and positioned below Ride Details

🤖 Generated with [Claude Code](https://claude.com/claude-code)