### PR TITLE
Serve site from custom domain grandvalleydirtbikerally.com

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -45,8 +45,8 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        # run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
-        run: bundle exec jekyll build --baseurl "/gvdbr" # Ugly hardcode, configure-pages action isn't outputting properly currently
+        # Custom domain (grandvalleydirtbikerally.com) is served at the root, so no baseurl prefix.
+        run: bundle exec jekyll build --baseurl ""
         env:
           JEKYLL_ENV: production
       - name: Upload artifact

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Jekyll-based static website for the Grand Valley Dirt Bike Rally (GVDBR), an annual event hosted by the Motorcycle Trail Riding Association (MTRA). Deployed to GitHub Pages at `https://mtragj.github.io/gvdbr/`.
+Jekyll-based static website for the Grand Valley Dirt Bike Rally (GVDBR), an annual event hosted by the Motorcycle Trail Riding Association (MTRA). Deployed to GitHub Pages and served at the custom domain `https://grandvalleydirtbikerally.com/` (configured via the root `CNAME` file).
 
 ## Branching Workflow
 
@@ -23,7 +23,7 @@ bundle install
 
 # Run local development server
 bundle exec jekyll server --config _config.yml,_config_dev.yml
-# Access at http://127.0.0.1:4000/gvdbr/
+# Access at http://127.0.0.1:4000/
 ```
 
 The site auto-regenerates on content file changes. For template/layout changes, restart the server.
@@ -70,4 +70,4 @@ Name files descriptively with dimensions: `descriptive_name_1024_768.jpg`, `desc
 
 ## Deployment
 
-Automatic via GitHub Actions on push to `main`. The workflow builds Jekyll with baseurl `/gvdbr` and deploys to GitHub Pages.
+Automatic via GitHub Actions on push to `main`. The workflow builds Jekyll with an empty baseurl (the site is served at the root of the custom domain) and deploys to GitHub Pages. The root `CNAME` file tells GitHub Pages to serve the site at `grandvalleydirtbikerally.com`.

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+grandvalleydirtbikerally.com

--- a/_config.yml
+++ b/_config.yml
@@ -25,8 +25,8 @@ author: phlow
 
 # This URL is the main address for absolute links. Don't include a slash at the end.
 #
-url: 'https://mtragj.github.io'
-baseurl: '/gvdbr'
+url: 'https://grandvalleydirtbikerally.com'
+baseurl: ''
 
 # This is for the editing function in _/includes/improve_content
 # Leave it empty if your site is not on GitHub/GitHub Pages
@@ -38,8 +38,7 @@ improve_content: https://github.com/Phlow/feeling-responsive/edit/gh-pages
 # Example: <img src="{{ site.urlimg }}{{ post.image.title }}" />
 # Markdown-Example for posts ![Image Text]({{ site.urlimg }}image.jpg)
 #
-# urlimg: 'http://localhost:4000/gvdbr/images/' # TODO revert url before publishing
-urlimg: 'https://mtragj.github.io/gvdbr/images/' # TODO revert url before publishing
+urlimg: 'https://grandvalleydirtbikerally.com/images/'
 
 
 

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -5,9 +5,9 @@
 #
 # Start development with › $ jekyll serve --config _config.yml,_config_dev.yml
 
-url: 'http://localhost:4000/'
-baseurl: '/gvdbr'
-urlimg: 'http://localhost:4000/gvdbr/images/'
+url: 'http://localhost:4000'
+baseurl: ''
+urlimg: 'http://localhost:4000/images/'
 
 # See › https://github.com/jekyll/jekyll-gist#disabling-noscript-support
 gist:


### PR DESCRIPTION
## Summary
Switches the live site from the GitHub Pages project URL (`https://mtragj.github.io/gvdbr/`) to the custom domain `https://grandvalleydirtbikerally.com/`, so links no longer carry the `/gvdbr/` baseurl prefix. Also fixes local dev to serve at the root instead of `/gvdbr/`.

## Changes
- **`_config.yml`**: `url` → custom domain, `baseurl` → empty, `urlimg` → custom-domain images path (dropped the stale commented-out localhost line)
- **`_config_dev.yml`**: empty `baseurl` and root `urlimg` so `bundle exec jekyll serve` is reachable at `http://127.0.0.1:4000/` with no prefix
- **`.github/workflows/jekyll.yml`**: build with `--baseurl ""` instead of the hardcoded `/gvdbr`
- **`CNAME`** (new): tells GitHub Pages to serve the site at `grandvalleydirtbikerally.com`
- **`CLAUDE.md`**: updated stale URL/baseurl references

## Verification
- Dev build (`_config.yml,_config_dev.yml`) emits `http://localhost:4000/...` links with zero `/gvdbr/` occurrences
- Production build emits `https://grandvalleydirtbikerally.com/...` links, and the `CNAME` file is copied into `_site`

## Note
For the domain to resolve, DNS for `grandvalleydirtbikerally.com` must point at GitHub Pages (A/AAAA records, or a CNAME for `www`). Committing the `CNAME` file auto-sets the custom domain in the repo's Pages settings on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)