### PR TITLE
Underline the Where link in ride detail sidebars

### DIFF
--- a/_sass/_07_layout.scss
+++ b/_sass/_07_layout.scss
@@ -11,6 +11,7 @@
 - Masthead › xlarge-up
 - Breadcrumb
 - Meta
+- Sidebar
 - Jump to top
 - Footer
 - Subfooter
@@ -242,6 +243,21 @@ body.video cite { color: #fff; }
     text-decoration: none;
     color: $secondary-color;
   }
+
+
+
+/* Sidebar
+------------------------------------------------------------------- */
+
+/* Underline links in the details panel (Ride/Event/Volunteer sidebars) so
+   they read as links -- the global anchor style has no underline. */
+aside .panel li a {
+    text-decoration: underline;
+}
+aside .panel li a:hover {
+    text-decoration: none;
+    color: $secondary-color;
+}
 
 
 


### PR DESCRIPTION
## Summary

A user reported that the **Where** link in the Ride Details sidebar doesn't look like a link. The theme's global anchor style sets `text-decoration: none`, so it rendered as plain colored text.

This adds an underline to links inside the sidebar details panel, and removes it on hover (with the secondary color), matching the existing `.meta-info a` convention in `_07_layout.scss`.

## Scope

The selector is `aside .panel li a`, which is the shared markup for `_sidebar_ride.html`, `_sidebar_event.html`, and `_sidebar_volunteer.html` — so the event and volunteer "Where" links get the same treatment. Same complaint applies there, and it keeps the sidebars consistent.

The MTRA logo link lower in the sidebar is outside `.panel`, so it's unaffected.

## Testing

- `bundle exec jekyll build --config _config.yml` succeeds
- Compiled CSS contains `aside .panel li a{text-decoration:underline}`
- Verified the rendered ride page markup matches the selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)